### PR TITLE
Update To create backups

### DIFF
--- a/debian/novena-kernel-install-postinst
+++ b/debian/novena-kernel-install-postinst
@@ -18,7 +18,7 @@ if [ -f /boot/zimage  ]; then
 fi
 
 if [ -f /boot/zimage  ]; then
-cp "/boot/novena.dtb" "/usr/share/linux-novena/boot_backup/novena_backup.dtb"
+	cp "/boot/novena.dtb" "/usr/share/linux-novena/boot_backup/novena_backup.dtb"
 fi
 
 cp "$2" "/boot/zimage"

--- a/debian/novena-kernel-install-postinst
+++ b/debian/novena-kernel-install-postinst
@@ -1,18 +1,25 @@
 #!/bin/sh
 echo "Installing new kernel to /boot"
-
+#!/bin/sh
+echo "Backing up old kernel to /usr/share/linux-novena/boot_backup/"
 if [ ! -d /usr/share/linux-novena/boot_backup/ ]; then
 	mkdir /usr/share/linux-novena/boot_backup/
 fi
 if [ -f /boot/uImage ]; then
-cp /boot/uImage /usr/share/linux-novena/boot_backup/uImage_backup
-fi
-if [ -f /boot/uInitrd  ]; then
-cp /boot/uInitrd /usr/share/linux-novena/boot_backup/uInitrd_backup
+	cp /boot/uImage /usr/share/linux-novena/boot_backup/uImage_backup
 fi
 
-cp "/boot/zimage" "/usr/share/linux-novena/boot_backup/zimage_backup"
+if [ -f /boot/uInitrd  ]; then
+	cp /boot/uInitrd /usr/share/linux-novena/boot_backup/uInitrd_backup
+fi
+
+if [ -f /boot/zimage  ]; then
+	cp "/boot/zimage" "/usr/share/linux-novena/boot_backup/zimage_backup"
+fi
+
+if [ -f /boot/zimage  ]; then
 cp "/boot/novena.dtb" "/usr/share/linux-novena/boot_backup/novena_backup.dtb"
+fi
 
 cp "$2" "/boot/zimage"
 cp "$2.dtb" "/boot/novena.dtb"

--- a/debian/novena-kernel-install-postinst
+++ b/debian/novena-kernel-install-postinst
@@ -1,4 +1,18 @@
 #!/bin/sh
 echo "Installing new kernel to /boot"
+
+if [ ! -d /usr/share/linux-novena/boot_backup/ ]; then
+	mkdir /usr/share/linux-novena/boot_backup/
+fi
+if [ -f /boot/uImage ]; then
+cp /boot/uImage /usr/share/linux-novena/boot_backup/uImage_backup
+fi
+if [ -f /boot/uInitrd  ]; then
+cp /boot/uInitrd /usr/share/linux-novena/boot_backup/uInitrd_backup
+fi
+
+cp "/boot/zimage" "/usr/share/linux-novena/boot_backup/zimage_backup"
+cp "/boot/novena.dtb" "/usr/share/linux-novena/boot_backup/novena_backup.dtb"
+
 cp "$2" "/boot/zimage"
 cp "$2.dtb" "/boot/novena.dtb"

--- a/debian/novena-kernel-install-postinst
+++ b/debian/novena-kernel-install-postinst
@@ -17,7 +17,7 @@ if [ -f /boot/zimage  ]; then
 	cp "/boot/zimage" "/usr/share/linux-novena/boot_backup/zimage_backup"
 fi
 
-if [ -f /boot/zimage  ]; then
+if [ -f /boot/novena.dtb ]; then
 	cp "/boot/novena.dtb" "/usr/share/linux-novena/boot_backup/novena_backup.dtb"
 fi
 


### PR DESCRIPTION
This update creates backups of the old u-boot files to /usr/share/linux-novena/boot_backup/. That way, if something goes wrong and renders the system unbootable, the user can go into recovery mode and place these files back into the /boot folder.
