### PR TITLE
Disable relro when compiling 'mkimage'.

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -128,7 +128,7 @@ HOSTLOADLIBES_dumpimage := $(HOSTLOADLIBES_mkimage)
 HOSTLOADLIBES_fit_info := $(HOSTLOADLIBES_mkimage)
 HOSTLOADLIBES_fit_check_sign := $(HOSTLOADLIBES_mkimage)
 
-HOSTLDFLAGS += -T $(srctree)/tools/imagetool.lds
+HOSTLDFLAGS += -T $(srctree)/tools/imagetool.lds -z norelro
 
 hostprogs-$(CONFIG_EXYNOS5250) += mkexynosspl
 hostprogs-$(CONFIG_EXYNOS5420) += mkexynosspl


### PR DESCRIPTION
The 'imximage_generate' function dynamically determines header
size for the image, however, the header is stored in a
"linker-generated array" in the 'tools/mkimage', '.u_boot_list' ELF
section, which, while not marked read-only at compile-time, may be
dynamically marked as such at run-time by certain relro-enabled,
hardened toolchains, causing the program to segmentation fault when
it attempts to modify the header size. Prevent this by disabling
relro at compilation time.

Signed-off-by: Wade Cline wadecline@hotmail.com

---

You can probably test this on your own system by changing '-z norelro' to '-z relro', which should trigger the Segmentation Fault if you run 'make mrproper; make novena_defconfig; make'.
